### PR TITLE
Fix integer overflow when computing bounding box in NvDsInferParseYoloV4 and NvDsInferParseYoloV5

### DIFF
--- a/Deepstream 5.0/nvdsinfer_custom_impl_Yolo/nvdsparsebbox_Yolo.cpp
+++ b/Deepstream 5.0/nvdsinfer_custom_impl_Yolo/nvdsparsebbox_Yolo.cpp
@@ -156,8 +156,8 @@ static bool NvDsInferParseYoloV5(
 	    NvDsInferParseObjectInfo oinfo;        
         
 	    oinfo.classId = r.class_id;
-	    oinfo.left    = static_cast<unsigned int>(r.bbox[0]-r.bbox[2]*0.5f);
-	    oinfo.top     = static_cast<unsigned int>(r.bbox[1]-r.bbox[3]*0.5f);
+	    oinfo.left    = static_cast<unsigned int>(std::max(0.0f, r.bbox[0]-r.bbox[2]*0.5f));
+	    oinfo.top     = static_cast<unsigned int>(std::max(0.0f, r.bbox[1]-r.bbox[3]*0.5f));
 	    oinfo.width   = static_cast<unsigned int>(r.bbox[2]);
 	    oinfo.height  = static_cast<unsigned int>(r.bbox[3]);
 	    oinfo.detectionConfidence = r.conf;
@@ -193,8 +193,8 @@ static bool NvDsInferParseYoloV4(
 	    NvDsInferParseObjectInfo oinfo;        
         
 	    oinfo.classId = r.class_id;
-	    oinfo.left    = static_cast<unsigned int>(r.bbox[0]-r.bbox[2]*0.5f);
-	    oinfo.top     = static_cast<unsigned int>(r.bbox[1]-r.bbox[3]*0.5f);
+	    oinfo.left    = static_cast<unsigned int>(std::max(0.0f, r.bbox[0]-r.bbox[2]*0.5f));
+	    oinfo.top     = static_cast<unsigned int>(std::max(0.0f, r.bbox[1]-r.bbox[3]*0.5f));
 	    oinfo.width   = static_cast<unsigned int>(r.bbox[2]);
 	    oinfo.height  = static_cast<unsigned int>(r.bbox[3]);
 	    oinfo.detectionConfidence = r.conf;


### PR DESCRIPTION
Top and left values of a bounding box can sometimes be negative in degenerate cases. For instance, if an object is very close to the border of the image, top value could be -1. This would cause integer overflow due to assignment of negative values to unsigned int.
The fix prevents the integer overflow in functions NvDsInferParseYoloV4 and NvDsInferParseYoloV5 by guaranteeing that top and left values are always nonnegative.